### PR TITLE
Improved support for arguments coloring

### DIFF
--- a/syntaxes/udev.tmLanguage.json
+++ b/syntaxes/udev.tmLanguage.json
@@ -12,7 +12,7 @@
 		"arguments": {
 			"patterns": [{
 				"name": "constant.language",
-				"match": "{[a-zA-Z]+}"
+				"match": "{[a-zA-Z_]+}"
 			}]
 		},
 		"comments": {


### PR DESCRIPTION
Hi,

thanks for a great tool. Found small bug, so let me contribute. Cheers.

Added support to colour arguments with "_", ie ATTR{ID_BUS} or ATTR{ID_SERIAL}